### PR TITLE
Buffer ffprobe stdout; parse after process exit to avoid partial chunks

### DIFF
--- a/src/ffprobe.js
+++ b/src/ffprobe.js
@@ -24,19 +24,38 @@ export async function runFfprobeCommandAsync(contextId, args) {
   } catch (e) {}
 
   const child = childProcess.spawn("ffprobe", args, {});
+  const stderrStream = fs.createWriteStream(stderrOutPath);
+  child.stderr.pipe(stderrStream);
 
   const ret = {
     streams: [],
     frames: [],
   };
 
+  let stdoutBuf = "";
   child.stdout.on("data", (data) => {
-    let str = data.toString();
+    stdoutBuf += data.toString();
+  });
+
+  child.on("error", (err) => {
+    throw new Error(`ffprobe child error: ${err.message}`);
+  });
+
+  const exitCode = await new Promise((resolve) => {
+    child.on("close", resolve);
+  });
+  if (exitCode) {
+    throw new Error(
+      `ffprobe subprocess exited with ${exitCode}, log at: ${stderrOutPath}`
+    );
+  }
+
+  // parse buffered stdout after process finishes to avoid partial chunks
+  {
+    let str = stdoutBuf;
     let idx;
 
-    let numItems = 0;
     while ((idx = str.indexOf("[")) !== -1) {
-      numItems++;
       str = str.substring(idx);
 
       if (str.indexOf("[FRAME]") === 0) {
@@ -68,19 +87,6 @@ export async function runFfprobeCommandAsync(contextId, args) {
         throw new Error("Unsupported data");
       }
     }
-  });
-
-  child.on("error", (err) => {
-    throw new Error(`ffprobe child error: ${err.message}`);
-  });
-
-  const exitCode = await new Promise((resolve) => {
-    child.on("close", resolve);
-  });
-  if (exitCode) {
-    throw new Error(
-      `ffprobe subprocess exited with ${exitCode}, log at: ${stderrOutPath}`
-    );
   }
 
   return ret;


### PR DESCRIPTION
- Buffer ffprobe stdout and parse once the process exits to prevent chunk-splitting that caused "frame end marker missing" errors. The previous implementation expected `child.stdout.on("data", ...)` to only be called once with the complete output but this callback can actually run multiple times with partial data chunks.
- Correctly pipe stderr to a temp file - previously the file was always empty as no output was actually written there.
- No API changes; behavior is identical aside from improved robustness.