### PR TITLE
Add missing submodule init step to VCSRender build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ In the VCS SDK repo, perform the following install operations once:
   `cd js; yarn install`
 
 - Build the VCSRender tool:
-  `cd server-render/vcsrender; meson setup build; ninja -C build`
+  `cd server-render/vcsrender`
+
+  First, initialize submodules (run once from the VCS SDK repo root):
+  `git submodule init && git submodule update`
+
+  Then build:
+  `meson setup build; ninja -C build`
 
 Note that these tools have their individual dependencies:
 


### PR DESCRIPTION
## Summary
- Adds the required `git submodule init && git submodule update` step to the VCSRender build instructions in the README
- Without this step, builds fail due to missing submodule dependencies (e.g. `canvex-skia`)
- Matches the build order documented in the [upstream vcsrender README](https://github.com/daily-co/daily-vcs/tree/main/server-render/vcsrender#building)

## Test plan
- [ ] Verify the updated README renders correctly on GitHub
- [ ] Confirm instruction order matches upstream docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)