### PR TITLE
Add --min-gap-duration CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ You can also provide an output path using the -o option.
 
 By default, audio tracks are re-encoded to AAC. Pass `--audio-codec wav` to emit a mono 48 kHz PCM WAV instead. (MP4 muxing is only performed when an AAC track is produced, since MP4 does not accept PCM audio.)
 
+By default, gaps longer than 0.5 seconds in a video track are filled with black frames. For screenshare tracks (which produce frames only when content changes), this can cause unwanted black flashes. Use `--min-gap-duration` to increase the threshold:
+
+```
+npm run normalize-track -- -i screenshare-video.webm --min-gap-duration 30
+```
+
+This sets the minimum gap duration to 30 seconds, so only gaps longer than 30s will be filled with black frames. Shorter gaps will hold the last frame.
+
 ### gen-manifest
 
 Generates a raw-tracks manifest file by inspecting filenames in a directory containing raw-tracks recordings made on Daily. This is used with the legacy `composite-from-manifest` tool.

--- a/normalize-track.js
+++ b/normalize-track.js
@@ -23,6 +23,9 @@ const args = parseArgs({
     'audio-codec': {
       type: 'string',
     },
+    'min-gap-duration': {
+      type: 'string',
+    },
   },
 });
 
@@ -44,6 +47,14 @@ if (!['aac', 'wav'].includes(audioCodec)) {
   process.exit(1);
 }
 
+const minGapDuration = args.values['min-gap-duration']
+  ? parseFloat(args.values['min-gap-duration'])
+  : undefined;
+if (minGapDuration !== undefined && (!Number.isFinite(minGapDuration) || minGapDuration < 0)) {
+  console.error('min-gap-duration must be a non-negative number (in seconds)');
+  process.exit(1);
+}
+
 let videoPath;
 let audioPath;
 let combinedOutputPath;
@@ -55,7 +66,11 @@ for (const inputPath of args.values.input) {
   }
   const basename = Path.basename(inputPath, Path.extname(inputPath));
 
-  const analysis = await analyzeTrack(`analyze_${basename}`, inputPath);
+  const analyzeOpts = {};
+  if (minGapDuration !== undefined) {
+    analyzeOpts.minGapDurationInSecs = minGapDuration;
+  }
+  const analysis = await analyzeTrack(`analyze_${basename}`, inputPath, analyzeOpts);
 
   if (analysis.isVideo) {
     const videoOutputPath = Path.resolve(


### PR DESCRIPTION
In the case of screenshare tracks: override the min-gap-duration in case the frames are not generated (variable frame-rate) 